### PR TITLE
[DE-85] Feature/bad records

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ on:
     types: [ opened, synchronize, reopened ]
     branches:
       - main
+      - devel
 
 jobs:
 

--- a/README.md
+++ b/README.md
@@ -346,6 +346,8 @@ df.write
 
 - on batch reading, bad records are not tolerated and will make the job fail 
 - in read jobs using `stream=true` (default), possible AQL warnings are only logged at the end of each the read task
+- for `content-type=vpack` deserialization casts don't work well, i.e. reading a document having a numeric value field
+  whereas the related read schema requires a string value for such field
 
 ## Demo
 

--- a/README.md
+++ b/README.md
@@ -255,7 +255,8 @@ fail. To makes the job more resilient to temporary errors (i.e. connectivity pro
 will be retried (with another coordinator) if the configured `overwrite.mode` allows for idempotent requests, namely: 
 - `replace`
 - `ignore`
-- `update`
+- `update` with `keep.null=true`
+
 These configurations of `overwrite.mode` would also be compatible with speculative execution of tasks.
 
 A failing batch-saving request is retried at most once for every coordinator. After that, if still failing, the write 

--- a/README.md
+++ b/README.md
@@ -352,8 +352,6 @@ df.write
 
 ## Current limitations
 
-- on corrupted records in batch reading, partial results are not supported. All fields other than the field configured 
-  by `columnNameOfCorruptRecord` are set to `null`
 - in read jobs using `stream=true` (default), possible AQL warnings are only logged at the end of each read task (BTS-671)
 - for `content-type=vpack`, implicit deserialization casts don't work well, i.e. reading a document having a field with 
   a numeric value whereas the related read schema requires a string value for such field

--- a/README.md
+++ b/README.md
@@ -352,6 +352,8 @@ df.write
 
 ## Current limitations
 
+- In Spark 2.4, on corrupted records in batch reading, partial results are not supported. All fields other than the
+  field configured by `columnNameOfCorruptRecord` are set to `null`
 - in read jobs using `stream=true` (default), possible AQL warnings are only logged at the end of each read task (BTS-671)
 - for `content-type=vpack`, implicit deserialization casts don't work well, i.e. reading a document having a field with 
   a numeric value whereas the related read schema requires a string value for such field

--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ To use in external Spark cluster, submit your application with the following par
 ### SSL
 
 To use TLS secured connections to ArangoDB, set `ssl.enabled` to `true` and either:
+- provide base64 encoded certificate as `ssl.cert.value` configuration entry and optionally set `ssl.*`, or
 - start Spark driver and workers with properly configured JVM default TrustStore, see 
   [link](https://spark.apache.org/docs/latest/security.html#ssl-configuration)
-- provide base64 encoded certificate as `ssl.cert.value` configuration entry and optionally set `ssl.*`, or
 
 ### Supported deployment topologies
 
@@ -345,8 +345,8 @@ df.write
 ## Current limitations
 
 - on batch reading, bad records are not tolerated and will make the job fail 
-- in read jobs using `stream=true` (default), possible AQL warnings are only logged at the end of each the read task
-- for `content-type=vpack` deserialization casts don't work well, i.e. reading a document having a numeric value field
+- in read jobs using `stream=true` (default), possible AQL warnings are only logged at the end of each read task
+- for `content-type=vpack` deserialization casts don't work well, i.e. reading a document having a numeric field
   whereas the related read schema requires a string value for such field
 
 ## Demo

--- a/README.md
+++ b/README.md
@@ -141,11 +141,10 @@ usersDF.filter(col("birthday") === "1982-12-15").show()
 - `fill.cache`: whether the query should store the data it reads in the RocksDB block cache (`true`|`false`)
 - `stream`: whether the query should be executed lazily, default `true`
 - `mode`: allows a mode for dealing with corrupt records during parsing:
-  - `PERMISSIVE` : when it meets a corrupted record, puts the malformed string into a field
-    configured by columnNameOfCorruptRecord, and sets malformed fields to null. To keep corrupt
-    records, an user can set a string type field named columnNameOfCorruptRecord in an
-    user-defined schema. If a schema does not have the field, it drops corrupt records during
-    parsing. When inferring a schema, it implicitly adds a columnNameOfCorruptRecord field in
+  - `PERMISSIVE` : when it meets a corrupted record, puts the malformed string into a field configured by 
+    `columnNameOfCorruptRecord`, and sets malformed fields to null. To keep corrupt records, a user can set a string 
+    type field named columnNameOfCorruptRecord in a user-defined schema. If a schema does not have the field, it drops 
+    corrupt records during parsing. When inferring a schema, it implicitly adds a `columnNameOfCorruptRecord` field in
     an output schema
   - `DROPMALFORMED`: ignores the whole corrupted records
   - `FAILFAST`: throws an exception when it meets corrupted records
@@ -355,10 +354,10 @@ df.write
 
 - on corrupted records in batch reading, partial results are not supported. All fields other than the field configured 
   by `columnNameOfCorruptRecord` are set to `null`
-- in read jobs using `stream=true` (default), possible AQL warnings are only logged at the end of each read task
-- for `content-type=vpack` deserialization casts don't work well, i.e. reading a document having a numeric field
-  whereas the related read schema requires a string value for such field
-- when reading or writing, dates and timestamps fields interpreted to be of UTC time zone
+- in read jobs using `stream=true` (default), possible AQL warnings are only logged at the end of each read task (BTS-671)
+- for `content-type=vpack`, implicit deserialization casts don't work well, i.e. reading a document having a field with 
+  a numeric value whereas the related read schema requires a string value for such field
+- dates and timestamps fields are interpreted to be in UTC time zone
 
 ## Demo
 

--- a/arangodb-spark-commons/src/main/scala/org/apache/spark/sql/arangodb/commons/ArangoOptions.scala
+++ b/arangodb-spark-commons/src/main/scala/org/apache/spark/sql/arangodb/commons/ArangoOptions.scala
@@ -28,7 +28,7 @@ import java.io.ByteArrayInputStream
 import java.security.KeyStore
 import java.security.cert.CertificateFactory
 import java.util
-import java.util.Base64
+import java.util.{Base64, Locale}
 import javax.net.ssl.{SSLContext, TrustManagerFactory}
 import scala.collection.JavaConverters.mapAsScalaMapConverter
 
@@ -36,7 +36,9 @@ import scala.collection.JavaConverters.mapAsScalaMapConverter
 /**
  * @author Michele Rastelli
  */
-class ArangoOptions(private val options: Map[String, String]) extends Serializable {
+class ArangoOptions(opts: Map[String, String]) extends Serializable {
+  private val options: Map[String, String] = opts.map(e => (e._1.toLowerCase(Locale.US), e._2))
+
   lazy val driverOptions: ArangoDriverOptions = new ArangoDriverOptions(options)
   lazy val readOptions: ArangoReadOptions = new ArangoReadOptions(options)
   lazy val writeOptions: ArangoWriteOptions = new ArangoWriteOptions(options)
@@ -87,7 +89,7 @@ object ArangoOptions {
   val FILL_BLOCK_CACHE = "fill.cache"
   val STREAM = "stream"
   val PARSE_MODE = "mode"
-  val CORRUPT_RECORDS_COLUMN = "columnNameOfCorruptRecord"
+  val CORRUPT_RECORDS_COLUMN = "columnnameofcorruptrecord"
 
   // write options
   val NUMBER_OF_SHARDS = "table.shards"

--- a/arangodb-spark-commons/src/main/scala/org/apache/spark/sql/arangodb/commons/ArangoOptions.scala
+++ b/arangodb-spark-commons/src/main/scala/org/apache/spark/sql/arangodb/commons/ArangoOptions.scala
@@ -22,6 +22,7 @@ package org.apache.spark.sql.arangodb.commons
 
 import com.arangodb.{ArangoDB, entity}
 import com.arangodb.model.OverwriteMode
+import org.apache.spark.sql.catalyst.util.{ParseMode, PermissiveMode}
 
 import java.io.ByteArrayInputStream
 import java.security.KeyStore
@@ -85,6 +86,7 @@ object ArangoOptions {
   val SAMPLE_SIZE = "sample.size"
   val FILL_BLOCK_CACHE = "fill.cache"
   val STREAM = "stream"
+  val PARSE_MODE = "mode"
 
   // write options
   val NUMBER_OF_SHARDS = "table.shards"
@@ -175,6 +177,7 @@ class ArangoReadOptions(options: Map[String, String]) extends CommonOptions(opti
     else throw new IllegalArgumentException("Either collection or query must be defined")
   val fillBlockCache: Option[Boolean] = options.get(ArangoOptions.FILL_BLOCK_CACHE).map(_.toBoolean)
   val stream: Boolean = options.getOrElse(ArangoOptions.STREAM, "true").toBoolean
+  val parseMode: ParseMode = options.get(ArangoOptions.PARSE_MODE).map(ParseMode.fromString).getOrElse(PermissiveMode)
 }
 
 class ArangoWriteOptions(options: Map[String, String]) extends CommonOptions(options) {

--- a/arangodb-spark-commons/src/main/scala/org/apache/spark/sql/arangodb/commons/ArangoOptions.scala
+++ b/arangodb-spark-commons/src/main/scala/org/apache/spark/sql/arangodb/commons/ArangoOptions.scala
@@ -87,6 +87,7 @@ object ArangoOptions {
   val FILL_BLOCK_CACHE = "fill.cache"
   val STREAM = "stream"
   val PARSE_MODE = "mode"
+  val CORRUPT_RECORDS_COLUMN = "columnNameOfCorruptRecord"
 
   // write options
   val NUMBER_OF_SHARDS = "table.shards"
@@ -178,6 +179,7 @@ class ArangoReadOptions(options: Map[String, String]) extends CommonOptions(opti
   val fillBlockCache: Option[Boolean] = options.get(ArangoOptions.FILL_BLOCK_CACHE).map(_.toBoolean)
   val stream: Boolean = options.getOrElse(ArangoOptions.STREAM, "true").toBoolean
   val parseMode: ParseMode = options.get(ArangoOptions.PARSE_MODE).map(ParseMode.fromString).getOrElse(PermissiveMode)
+  val columnNameOfCorruptRecord: String = options.getOrElse(ArangoOptions.CORRUPT_RECORDS_COLUMN, "")
 }
 
 class ArangoWriteOptions(options: Map[String, String]) extends CommonOptions(options) {

--- a/arangodb-spark-commons/src/main/scala/org/apache/spark/sql/arangodb/commons/ArangoUtils.scala
+++ b/arangodb-spark-commons/src/main/scala/org/apache/spark/sql/arangodb/commons/ArangoUtils.scala
@@ -1,6 +1,6 @@
 package org.apache.spark.sql.arangodb.commons
 
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{StringType, StructField, StructType}
 import org.apache.spark.sql.{Encoders, SparkSession}
 
 /**
@@ -17,10 +17,15 @@ object ArangoUtils {
     client.shutdown()
 
     val spark = SparkSession.getActiveSession.get
-    spark
+    val schema = spark
       .read
       .json(spark.createDataset(sampleEntries)(Encoders.STRING))
       .schema
+
+    if (options.readOptions.columnNameOfCorruptRecord.isEmpty)
+      schema
+    else
+      schema.add(StructField(options.readOptions.columnNameOfCorruptRecord, StringType, nullable = true))
   }
 
 }

--- a/arangodb-spark-datasource-2.4/src/main/scala/org/apache/spark/sql/arangodb/datasource/mapping/ArangoParserImpl.scala
+++ b/arangodb-spark-datasource-2.4/src/main/scala/org/apache/spark/sql/arangodb/datasource/mapping/ArangoParserImpl.scala
@@ -42,5 +42,5 @@ class VPackArangoParser(schema: DataType)
   extends ArangoParserImpl(
     schema,
     createOptions(new VPackFactory()),
-    (bytes: Array[Byte]) => UTF8String.fromString(new VPackParser.Builder().build().toJson(new VPackSlice(bytes)))
+    (bytes: Array[Byte]) => UTF8String.fromString(new VPackParser.Builder().build().toJson(new VPackSlice(bytes), true))
   )

--- a/arangodb-spark-datasource-2.4/src/main/scala/org/apache/spark/sql/arangodb/datasource/reader/ArangoCollectionPartitionReader.scala
+++ b/arangodb-spark-datasource-2.4/src/main/scala/org/apache/spark/sql/arangodb/datasource/reader/ArangoCollectionPartitionReader.scala
@@ -1,15 +1,17 @@
 package org.apache.spark.sql.arangodb.datasource.reader
 
 import com.arangodb.entity.CursorEntity.Warning
-import com.arangodb.velocypack.VPackSlice
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.arangodb.commons.mapping.ArangoParserProvider
 import org.apache.spark.sql.arangodb.commons.utils.PushDownCtx
 import org.apache.spark.sql.arangodb.commons.{ArangoClient, ArangoOptions, ContentType}
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.execution.datasources.FailureSafeParser
 import org.apache.spark.sql.sources.v2.reader.InputPartitionReader
+import org.apache.spark.sql.types.StructType
 
 import java.nio.charset.StandardCharsets
+import scala.annotation.tailrec
 import scala.collection.JavaConverters.iterableAsScalaIterableConverter
 
 
@@ -21,19 +23,31 @@ class ArangoCollectionPartitionReader(
 
   // override endpoints with partition endpoint
   private val options = opts.updated(ArangoOptions.ENDPOINTS, inputPartition.endpoint)
-  private val parser = ArangoParserProvider().of(options.readOptions.contentType, ctx.requiredSchema)
+  private val actualSchema = StructType(ctx.requiredSchema.filterNot(_.name == "columnNameOfCorruptRecord"))
+  private val parser = ArangoParserProvider().of(options.readOptions.contentType, actualSchema)
+  private val safeParser = new FailureSafeParser[Array[Byte]](
+    parser.parse(_).toSeq,
+    options.readOptions.parseMode,
+    ctx.requiredSchema,
+    "columnNameOfCorruptRecord")
   private val client = ArangoClient(options)
-  private val iterator = client.readCollectionPartition(inputPartition.shardId, ctx)
+  private val iterator = client.readCollectionPartition(inputPartition.shardId, ctx.filters, actualSchema)
 
-  private var current: VPackSlice = _
+  var rowIterator: Iterator[InternalRow] = _
 
   // warnings of non stream AQL cursors are all returned along with the first batch
   if (!options.readOptions.stream) logWarns()
 
-  override def next: Boolean =
+  @tailrec
+  final override def next: Boolean =
     if (iterator.hasNext) {
-      current = iterator.next()
-      true
+      val current = iterator.next()
+      rowIterator = safeParser.parse(options.readOptions.contentType match {
+        case ContentType.VPack => current.toByteArray
+        case ContentType.Json => current.toString.getBytes(StandardCharsets.UTF_8)
+      })
+      if (rowIterator.hasNext) true
+      else next
     } else {
       // FIXME: https://arangodb.atlassian.net/browse/BTS-671
       // stream AQL cursors' warnings are only returned along with the final batch
@@ -41,10 +55,7 @@ class ArangoCollectionPartitionReader(
       false
     }
 
-  override def get: InternalRow = options.readOptions.contentType match {
-    case ContentType.VPack => parser.parse(current.toByteArray).head
-    case ContentType.Json => parser.parse(current.toString.getBytes(StandardCharsets.UTF_8)).head
-  }
+  override def get: InternalRow = rowIterator.next()
 
   override def close(): Unit = {
     iterator.close()

--- a/arangodb-spark-datasource-2.4/src/main/scala/org/apache/spark/sql/arangodb/datasource/reader/ArangoCollectionPartitionReader.scala
+++ b/arangodb-spark-datasource-2.4/src/main/scala/org/apache/spark/sql/arangodb/datasource/reader/ArangoCollectionPartitionReader.scala
@@ -23,13 +23,13 @@ class ArangoCollectionPartitionReader(
 
   // override endpoints with partition endpoint
   private val options = opts.updated(ArangoOptions.ENDPOINTS, inputPartition.endpoint)
-  private val actualSchema = StructType(ctx.requiredSchema.filterNot(_.name == "columnNameOfCorruptRecord"))
+  private val actualSchema = StructType(ctx.requiredSchema.filterNot(_.name == options.readOptions.columnNameOfCorruptRecord))
   private val parser = ArangoParserProvider().of(options.readOptions.contentType, actualSchema)
   private val safeParser = new FailureSafeParser[Array[Byte]](
     parser.parse(_).toSeq,
     options.readOptions.parseMode,
     ctx.requiredSchema,
-    "columnNameOfCorruptRecord")
+    options.readOptions.columnNameOfCorruptRecord)
   private val client = ArangoClient(options)
   private val iterator = client.readCollectionPartition(inputPartition.shardId, ctx.filters, actualSchema)
 

--- a/arangodb-spark-datasource-2.4/src/main/scala/org/apache/spark/sql/arangodb/datasource/reader/ArangoDataSourceReader.scala
+++ b/arangodb-spark-datasource-2.4/src/main/scala/org/apache/spark/sql/arangodb/datasource/reader/ArangoDataSourceReader.scala
@@ -18,7 +18,7 @@ class ArangoDataSourceReader(tableSchema: StructType, options: ArangoOptions) ex
   with SupportsPushDownRequiredColumns
   with Logging {
 
-  verifyColumnNameOfCorruptRecord(tableSchema, "columnNameOfCorruptRecord")
+  verifyColumnNameOfCorruptRecord(tableSchema, options.readOptions.columnNameOfCorruptRecord)
 
   // fully or partially applied filters
   private var appliedPushableFilters: Array[PushableFilter] = Array()

--- a/arangodb-spark-datasource-2.4/src/main/scala/org/apache/spark/sql/arangodb/datasource/reader/ArangoDataSourceReader.scala
+++ b/arangodb-spark-datasource-2.4/src/main/scala/org/apache/spark/sql/arangodb/datasource/reader/ArangoDataSourceReader.scala
@@ -39,26 +39,30 @@ class ArangoDataSourceReader(tableSchema: StructType, options: ArangoOptions) ex
       .map(it => new ArangoCollectionPartition(it._1, it._2, new PushDownCtx(readSchema(), appliedPushableFilters), options))
 
   override def pushFilters(filters: Array[Filter]): Array[Filter] = {
+    // filters related to columnNameOfCorruptRecord are not pushed down
+    val isCorruptRecordFilter = (f: Filter) => f.references.contains(options.readOptions.columnNameOfCorruptRecord)
+    val ignoredFilters = filters.filter(isCorruptRecordFilter)
     val filtersBySupport = filters
+      .filterNot(isCorruptRecordFilter)
       .map(f => (f, PushableFilter(f, tableSchema)))
       .groupBy(_._2.support())
 
     val fullSupp = filtersBySupport.getOrElse(FilterSupport.FULL, Array())
     val partialSupp = filtersBySupport.getOrElse(FilterSupport.PARTIAL, Array())
-    val noneSupp = filtersBySupport.getOrElse(FilterSupport.NONE, Array())
+    val noneSupp = filtersBySupport.getOrElse(FilterSupport.NONE, Array()).map(_._1) ++ ignoredFilters
 
     val appliedFilters = fullSupp ++ partialSupp
     appliedPushableFilters = appliedFilters.map(_._2)
     appliedSparkFilters = appliedFilters.map(_._1)
 
     if (fullSupp.nonEmpty)
-      logInfo(s"Fully supported filters (applied in AQL):\n\t${fullSupp.map(_._1).mkString("\n\t")}")
+      logInfo(s"Filters fully applied in AQL:\n\t${fullSupp.map(_._1).mkString("\n\t")}")
     if (partialSupp.nonEmpty)
-      logInfo(s"Partially supported filters (applied in AQL and Spark):\n\t${partialSupp.map(_._1).mkString("\n\t")}")
+      logInfo(s"Filters partially applied in AQL:\n\t${partialSupp.map(_._1).mkString("\n\t")}")
     if (noneSupp.nonEmpty)
-      logInfo(s"Not supported filters (applied in Spark):\n\t${noneSupp.map(_._1).mkString("\n\t")}")
+      logInfo(s"Filters not applied in AQL:\n\t${noneSupp.mkString("\n\t")}")
 
-    (partialSupp ++ noneSupp).map(_._1)
+    partialSupp.map(_._1) ++ noneSupp
   }
 
   override def pushedFilters(): Array[Filter] = appliedSparkFilters

--- a/arangodb-spark-datasource-2.4/src/main/scala/org/apache/spark/sql/arangodb/datasource/reader/ArangoQueryReader.scala
+++ b/arangodb-spark-datasource-2.4/src/main/scala/org/apache/spark/sql/arangodb/datasource/reader/ArangoQueryReader.scala
@@ -17,13 +17,13 @@ import scala.collection.JavaConverters.iterableAsScalaIterableConverter
 class ArangoQueryReader(schema: StructType, options: ArangoOptions) extends InputPartitionReader[InternalRow]
   with Logging {
 
-  private val actualSchema = StructType(schema.filterNot(_.name == "columnNameOfCorruptRecord"))
+  private val actualSchema = StructType(schema.filterNot(_.name == options.readOptions.columnNameOfCorruptRecord))
   private val parser = ArangoParserProvider().of(options.readOptions.contentType, actualSchema)
   private val safeParser = new FailureSafeParser[Array[Byte]](
     parser.parse(_).toSeq,
     options.readOptions.parseMode,
     schema,
-    "columnNameOfCorruptRecord")
+    options.readOptions.columnNameOfCorruptRecord)
   private val client = ArangoClient(options)
   private val iterator = client.readQuery()
 

--- a/arangodb-spark-datasource-3.1/src/main/scala/org/apache/spark/sql/arangodb/datasource/mapping/ArangoParserImpl.scala
+++ b/arangodb-spark-datasource-3.1/src/main/scala/org/apache/spark/sql/arangodb/datasource/mapping/ArangoParserImpl.scala
@@ -44,5 +44,5 @@ class VPackArangoParser(schema: DataType)
   extends ArangoParserImpl(
     schema,
     createOptions(new VPackFactoryBuilder().build()),
-    (bytes: Array[Byte]) => UTF8String.fromString(new VPackParser.Builder().build().toJson(new VPackSlice(bytes)))
+    (bytes: Array[Byte]) => UTF8String.fromString(new VPackParser.Builder().build().toJson(new VPackSlice(bytes), true))
   )

--- a/arangodb-spark-datasource-3.1/src/main/scala/org/apache/spark/sql/arangodb/datasource/reader/ArangoCollectionPartitionReader.scala
+++ b/arangodb-spark-datasource-3.1/src/main/scala/org/apache/spark/sql/arangodb/datasource/reader/ArangoCollectionPartitionReader.scala
@@ -20,13 +20,13 @@ class ArangoCollectionPartitionReader(inputPartition: ArangoCollectionPartition,
 
   // override endpoints with partition endpoint
   private val options = opts.updated(ArangoOptions.ENDPOINTS, inputPartition.endpoint)
-  private val actualSchema = StructType(ctx.requiredSchema.filterNot(_.name == "columnNameOfCorruptRecord"))
+  private val actualSchema = StructType(ctx.requiredSchema.filterNot(_.name == options.readOptions.columnNameOfCorruptRecord))
   private val parser = ArangoParserProvider().of(options.readOptions.contentType, actualSchema)
   private val safeParser = new FailureSafeParser[Array[Byte]](
     parser.parse,
     options.readOptions.parseMode,
     ctx.requiredSchema,
-    "columnNameOfCorruptRecord")
+    options.readOptions.columnNameOfCorruptRecord)
   private val client = ArangoClient(options)
   private val iterator = client.readCollectionPartition(inputPartition.shardId, ctx.filters, actualSchema)
 

--- a/arangodb-spark-datasource-3.1/src/main/scala/org/apache/spark/sql/arangodb/datasource/reader/ArangoCollectionPartitionReader.scala
+++ b/arangodb-spark-datasource-3.1/src/main/scala/org/apache/spark/sql/arangodb/datasource/reader/ArangoCollectionPartitionReader.scala
@@ -6,7 +6,6 @@ import org.apache.spark.sql.arangodb.commons.mapping.ArangoParserProvider
 import org.apache.spark.sql.arangodb.commons.utils.PushDownCtx
 import org.apache.spark.sql.arangodb.commons.{ArangoClient, ArangoOptions, ContentType}
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.catalyst.expressions.ExprUtils
 import org.apache.spark.sql.catalyst.util.FailureSafeParser
 import org.apache.spark.sql.connector.read.PartitionReader
 import org.apache.spark.sql.types.StructType
@@ -30,9 +29,6 @@ class ArangoCollectionPartitionReader(inputPartition: ArangoCollectionPartition,
     "columnNameOfCorruptRecord")
   private val client = ArangoClient(options)
   private val iterator = client.readCollectionPartition(inputPartition.shardId, ctx.filters, actualSchema)
-
-  // FIXME: mv in driver
-  ExprUtils.verifyColumnNameOfCorruptRecord(ctx.requiredSchema, "columnNameOfCorruptRecord")
 
   var rowIterator: Iterator[InternalRow] = _
 

--- a/arangodb-spark-datasource-3.1/src/main/scala/org/apache/spark/sql/arangodb/datasource/reader/ArangoQueryReader.scala
+++ b/arangodb-spark-datasource-3.1/src/main/scala/org/apache/spark/sql/arangodb/datasource/reader/ArangoQueryReader.scala
@@ -16,13 +16,13 @@ import scala.collection.JavaConverters.iterableAsScalaIterableConverter
 
 class ArangoQueryReader(schema: StructType, options: ArangoOptions) extends PartitionReader[InternalRow] with Logging {
 
-  private val actualSchema = StructType(schema.filterNot(_.name == "columnNameOfCorruptRecord"))
+  private val actualSchema = StructType(schema.filterNot(_.name == options.readOptions.columnNameOfCorruptRecord))
   private val parser = ArangoParserProvider().of(options.readOptions.contentType, actualSchema)
   private val safeParser = new FailureSafeParser[Array[Byte]](
     parser.parse,
     options.readOptions.parseMode,
     schema,
-    "columnNameOfCorruptRecord")
+    options.readOptions.columnNameOfCorruptRecord)
   private val client = ArangoClient(options)
   private val iterator = client.readQuery()
 

--- a/arangodb-spark-datasource-3.1/src/main/scala/org/apache/spark/sql/arangodb/datasource/reader/ArangoQueryReader.scala
+++ b/arangodb-spark-datasource-3.1/src/main/scala/org/apache/spark/sql/arangodb/datasource/reader/ArangoQueryReader.scala
@@ -1,7 +1,6 @@
 package org.apache.spark.sql.arangodb.datasource.reader
 
 import com.arangodb.entity.CursorEntity.Warning
-import com.arangodb.velocypack.VPackSlice
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.arangodb.commons.mapping.ArangoParserProvider
 import org.apache.spark.sql.arangodb.commons.{ArangoClient, ArangoOptions, ContentType}
@@ -17,7 +16,8 @@ import scala.collection.JavaConverters.iterableAsScalaIterableConverter
 
 class ArangoQueryReader(schema: StructType, options: ArangoOptions) extends PartitionReader[InternalRow] with Logging {
 
-  private val parser = ArangoParserProvider().of(options.readOptions.contentType, schema)
+  private val actualSchema = StructType(schema.filterNot(_.name == "columnNameOfCorruptRecord"))
+  private val parser = ArangoParserProvider().of(options.readOptions.contentType, actualSchema)
   private val safeParser = new FailureSafeParser[Array[Byte]](
     parser.parse,
     options.readOptions.parseMode,

--- a/arangodb-spark-datasource-3.1/src/main/scala/org/apache/spark/sql/arangodb/datasource/reader/ArangoScan.scala
+++ b/arangodb-spark-datasource-3.1/src/main/scala/org/apache/spark/sql/arangodb/datasource/reader/ArangoScan.scala
@@ -2,10 +2,12 @@ package org.apache.spark.sql.arangodb.datasource.reader
 
 import org.apache.spark.sql.arangodb.commons.{ArangoClient, ArangoOptions, ReadMode}
 import org.apache.spark.sql.arangodb.commons.utils.PushDownCtx
+import org.apache.spark.sql.catalyst.expressions.ExprUtils
 import org.apache.spark.sql.connector.read.{Batch, InputPartition, PartitionReaderFactory, Scan}
 import org.apache.spark.sql.types.StructType
 
 class ArangoScan(ctx: PushDownCtx, options: ArangoOptions) extends Scan with Batch {
+  ExprUtils.verifyColumnNameOfCorruptRecord(ctx.requiredSchema, "columnNameOfCorruptRecord")
 
   override def readSchema(): StructType = ctx.requiredSchema
 

--- a/arangodb-spark-datasource-3.1/src/main/scala/org/apache/spark/sql/arangodb/datasource/reader/ArangoScan.scala
+++ b/arangodb-spark-datasource-3.1/src/main/scala/org/apache/spark/sql/arangodb/datasource/reader/ArangoScan.scala
@@ -7,7 +7,7 @@ import org.apache.spark.sql.connector.read.{Batch, InputPartition, PartitionRead
 import org.apache.spark.sql.types.StructType
 
 class ArangoScan(ctx: PushDownCtx, options: ArangoOptions) extends Scan with Batch {
-  ExprUtils.verifyColumnNameOfCorruptRecord(ctx.requiredSchema, "columnNameOfCorruptRecord")
+  ExprUtils.verifyColumnNameOfCorruptRecord(ctx.requiredSchema, options.readOptions.columnNameOfCorruptRecord)
 
   override def readSchema(): StructType = ctx.requiredSchema
 

--- a/integration-tests/src/test/scala/org/apache/spark/sql/arangodb/datasource/BadRecordsTest.scala
+++ b/integration-tests/src/test/scala/org/apache/spark/sql/arangodb/datasource/BadRecordsTest.scala
@@ -1,0 +1,96 @@
+package org.apache.spark.sql.arangodb.datasource
+
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.arangodb.commons.ArangoOptions
+import org.apache.spark.sql.types._
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class BadRecordsTest extends BaseSparkTest {
+  private val collectionName = "deserializationCast"
+
+  @ParameterizedTest
+  @ValueSource(strings = Array("vpack", "json"))
+  def stringAsInteger(contentType: String): Unit = testBadRecord(
+    StructType(Array(StructField("a", IntegerType))),
+    Seq(Map("a" -> "1")),
+    Seq("""{"a":"1"}"""),
+    contentType
+  )
+
+  @ParameterizedTest
+  @ValueSource(strings = Array("vpack", "json"))
+  def booleanAsInteger(contentType: String): Unit = testBadRecord(
+    StructType(Array(StructField("a", IntegerType))),
+    Seq(Map("a" -> true)),
+    Seq("""{"a":true}"""),
+    contentType
+  )
+
+  @ParameterizedTest
+  @ValueSource(strings = Array("vpack", "json"))
+  def stringAsDouble(contentType: String): Unit = testBadRecord(
+    StructType(Array(StructField("a", DoubleType))),
+    Seq(Map("a" -> "1")),
+    Seq("""{"a":"1"}"""),
+    contentType
+  )
+
+  @ParameterizedTest
+  @ValueSource(strings = Array("vpack", "json"))
+  def booleanAsDouble(contentType: String): Unit = testBadRecord(
+    StructType(Array(StructField("a", DoubleType))),
+    Seq(Map("a" -> true)),
+    Seq("""{"a":true}"""),
+    contentType
+  )
+
+  @ParameterizedTest
+  @ValueSource(strings = Array("vpack", "json"))
+  def stringAsBoolean(contentType: String): Unit = testBadRecord(
+    StructType(Array(StructField("a", BooleanType))),
+    Seq(Map("a" -> "true")),
+    Seq("""{"a":"true"}"""),
+    contentType
+  )
+
+  @ParameterizedTest
+  @ValueSource(strings = Array("vpack", "json"))
+  def numberAsBoolean(contentType: String): Unit = testBadRecord(
+    StructType(Array(StructField("a", BooleanType))),
+    Seq(Map("a" -> 1)),
+    Seq("""{"a":1}"""),
+    contentType
+  )
+
+  private def testBadRecord(
+                             schema: StructType,
+                             data: Iterable[Map[String, Any]],
+                             jsonData: Seq[String],
+                             contentType: String
+                           ) = {
+    doTestBadRecord(schema, data, jsonData, Map(ArangoOptions.CONTENT_TYPE -> contentType))
+    doTestBadRecord(
+      schema.add(StructField("columnNameOfCorruptRecord", StringType)), data, jsonData,
+      Map(
+        ArangoOptions.CONTENT_TYPE -> contentType,
+        "columnNameOfCorruptRecord" -> "columnNameOfCorruptRecord"
+      )
+    )
+  }
+
+  private def doTestBadRecord(
+                               schema: StructType,
+                               data: Iterable[Map[String, Any]],
+                               jsonData: Seq[String],
+                               options: Map[String, String] = Map.empty
+                             ) = {
+    import spark.implicits._
+    val dfFromJson: DataFrame = spark.read.schema(schema).options(options).json(jsonData.toDS)
+    dfFromJson.show()
+    val df = BaseSparkTest.createDF(collectionName, data, schema, options)
+    assertThat(df.collect()).isEqualTo(dfFromJson.collect())
+  }
+
+}

--- a/integration-tests/src/test/scala/org/apache/spark/sql/arangodb/datasource/BadRecordsTest.scala
+++ b/integration-tests/src/test/scala/org/apache/spark/sql/arangodb/datasource/BadRecordsTest.scala
@@ -114,8 +114,12 @@ class BadRecordsTest extends BaseSparkTest {
     import spark.implicits._
     val dfFromJson: DataFrame = spark.read.schema(schema).options(opts).json(jsonData.toDS)
     dfFromJson.show()
-    val df = BaseSparkTest.createDF(collectionName, data, schema, opts)
-    assertThat(df.collect()).isEqualTo(dfFromJson.collect())
+
+    val tableDF = BaseSparkTest.createDF(collectionName, data, schema, opts)
+    assertThat(tableDF.collect()).isEqualTo(dfFromJson.collect())
+
+    val queryDF = BaseSparkTest.createQueryDF(s"RETURN ${jsonData.head}", schema, opts)
+    assertThat(queryDF.collect()).isEqualTo(dfFromJson.collect())
   }
 
 }

--- a/integration-tests/src/test/scala/org/apache/spark/sql/arangodb/datasource/BadRecordsTest.scala
+++ b/integration-tests/src/test/scala/org/apache/spark/sql/arangodb/datasource/BadRecordsTest.scala
@@ -78,12 +78,12 @@ class BadRecordsTest extends BaseSparkTest {
 
     // PERMISSIVE with columnNameOfCorruptRecord
     doTestBadRecord(
-      schema.add(StructField("columnNameOfCorruptRecord", StringType)),
+      schema.add(StructField("corruptRecord", StringType)),
       data,
       jsonData,
       Map(
         ArangoOptions.CONTENT_TYPE -> contentType,
-        "columnNameOfCorruptRecord" -> "columnNameOfCorruptRecord"
+        ArangoOptions.CORRUPT_RECORDS_COLUMN -> "corruptRecord"
       )
     )
 

--- a/integration-tests/src/test/scala/org/apache/spark/sql/arangodb/datasource/BaseSparkTest.scala
+++ b/integration-tests/src/test/scala/org/apache/spark/sql/arangodb/datasource/BaseSparkTest.scala
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.databind.{JsonSerializer, ObjectMapper, SerializerProvider}
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import org.apache.spark.sql.arangodb.commons.ArangoOptions
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.junit.jupiter.api.{AfterEach, BeforeAll}
@@ -153,7 +154,7 @@ object BaseSparkTest {
     usersSchema
   )
 
-  def createDF(name: String, docs: Iterable[Any], schema: StructType): DataFrame = {
+  def createDF(name: String, docs: Iterable[Any], schema: StructType, contentType: String = "vpack"): DataFrame = {
     val col = db.collection(name)
     if (col.exists()) {
       col.truncate()
@@ -164,7 +165,7 @@ object BaseSparkTest {
 
     val df = spark.read
       .format(arangoDatasource)
-      .options(options + ("table" -> name))
+      .options(options + (ArangoOptions.COLLECTION -> name) + (ArangoOptions.CONTENT_TYPE -> contentType))
       .schema(schema)
       .load()
     df.createOrReplaceTempView(name)

--- a/integration-tests/src/test/scala/org/apache/spark/sql/arangodb/datasource/BaseSparkTest.scala
+++ b/integration-tests/src/test/scala/org/apache/spark/sql/arangodb/datasource/BaseSparkTest.scala
@@ -154,7 +154,7 @@ object BaseSparkTest {
     usersSchema
   )
 
-  def createDF(name: String, docs: Iterable[Any], schema: StructType, contentType: String = "vpack"): DataFrame = {
+  def createDF(name: String, docs: Iterable[Any], schema: StructType, additionalOptions: Map[String, String] = Map.empty): DataFrame = {
     val col = db.collection(name)
     if (col.exists()) {
       col.truncate()
@@ -165,7 +165,7 @@ object BaseSparkTest {
 
     val df = spark.read
       .format(arangoDatasource)
-      .options(options + (ArangoOptions.COLLECTION -> name) + (ArangoOptions.CONTENT_TYPE -> contentType))
+      .options(options ++ additionalOptions + (ArangoOptions.COLLECTION -> name))
       .schema(schema)
       .load()
     df.createOrReplaceTempView(name)

--- a/integration-tests/src/test/scala/org/apache/spark/sql/arangodb/datasource/BaseSparkTest.scala
+++ b/integration-tests/src/test/scala/org/apache/spark/sql/arangodb/datasource/BaseSparkTest.scala
@@ -35,6 +35,7 @@ class BaseSparkTest {
   }
 
   def isSingle: Boolean = BaseSparkTest.isSingle
+
   def isCluster: Boolean = !BaseSparkTest.isSingle
 }
 
@@ -171,6 +172,13 @@ object BaseSparkTest {
     df.createOrReplaceTempView(name)
     df
   }
+
+  def createQueryDF(query: String, schema: StructType, additionalOptions: Map[String, String] = Map.empty): DataFrame =
+    spark.read
+      .format(arangoDatasource)
+      .options(options ++ additionalOptions + (ArangoOptions.QUERY -> query))
+      .schema(schema)
+      .load()
 
   def dropTable(name: String): Unit = {
     db.collection(name).drop()

--- a/integration-tests/src/test/scala/org/apache/spark/sql/arangodb/datasource/DeserializationCastTest.scala
+++ b/integration-tests/src/test/scala/org/apache/spark/sql/arangodb/datasource/DeserializationCastTest.scala
@@ -1,0 +1,101 @@
+package org.apache.spark.sql.arangodb.datasource
+
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.types.{BooleanType, DoubleType, IntegerType, StringType, StructField, StructType}
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+/**
+ * FIXME: many vpack tests fail
+ */
+@Disabled
+class DeserializationCastTest extends BaseSparkTest {
+  private val collectionName = "deserializationCast"
+
+  @ParameterizedTest
+  @ValueSource(strings = Array("vpack", "json"))
+  def numberIntToStringCast(contentType: String): Unit = doTestBadRecordImplicitCast(
+    StructType(Array(StructField("a", StringType))),
+    Seq(Map("a" -> 1)),
+    Seq("""{"a":1}"""),
+    contentType
+  )
+
+  @ParameterizedTest
+  @ValueSource(strings = Array("vpack", "json"))
+  def numberDecToStringCast(contentType: String): Unit = doTestBadRecordImplicitCast(
+    StructType(Array(StructField("a", StringType))),
+    Seq(Map("a" -> 1.1)),
+    Seq("""{"a":1.1}"""),
+    contentType
+  )
+
+  @ParameterizedTest
+  @ValueSource(strings = Array("vpack", "json"))
+  def boolToStringCast(contentType: String): Unit = doTestBadRecordImplicitCast(
+    StructType(Array(StructField("a", StringType))),
+    Seq(Map("a" -> true)),
+    Seq("""{"a":true}"""),
+    contentType
+  )
+
+  @ParameterizedTest
+  @ValueSource(strings = Array("vpack", "json"))
+  def objectToStringCast(contentType: String): Unit = doTestBadRecordImplicitCast(
+    StructType(Array(StructField("a", StringType))),
+    Seq(Map("a" -> Map("b" -> "c"))),
+    Seq("""{"a":{"b":"c"}}"""),
+    contentType
+  )
+
+  @ParameterizedTest
+  @ValueSource(strings = Array("vpack", "json"))
+  def arrayToStringCast(contentType: String): Unit = doTestBadRecordImplicitCast(
+    StructType(Array(StructField("a", StringType))),
+    Seq(Map("a" -> Array(1, 2))),
+    Seq("""{"a":[1,2]}"""),
+    contentType
+  )
+
+  @ParameterizedTest
+  @ValueSource(strings = Array("vpack", "json"))
+  def nullToIntegerCast(contentType: String): Unit = doTestBadRecordImplicitCast(
+    StructType(Array(StructField("a", IntegerType, nullable = false))),
+    Seq(Map("a" -> null)),
+    Seq("""{"a":null}"""),
+    contentType
+  )
+
+  @ParameterizedTest
+  @ValueSource(strings = Array("vpack", "json"))
+  def nullToDoubleCast(contentType: String): Unit = doTestBadRecordImplicitCast(
+    StructType(Array(StructField("a", DoubleType, nullable = false))),
+    Seq(Map("a" -> null)),
+    Seq("""{"a":null}"""),
+    contentType
+  )
+
+  @ParameterizedTest
+  @ValueSource(strings = Array("vpack", "json"))
+  def nullAsBoolean(contentType: String): Unit = doTestBadRecordImplicitCast(
+    StructType(Array(StructField("a", BooleanType, nullable = false))),
+    Seq(Map("a" -> null)),
+    Seq("""{"a":null}"""),
+    contentType
+  )
+
+  private def doTestBadRecordImplicitCast(
+                                           schema: StructType,
+                                           data: Iterable[Map[String, Any]],
+                                           jsonData: Seq[String],
+                                           contentType: String
+                                         ) = {
+    import spark.implicits._
+    val dfFromJson: DataFrame = spark.read.schema(schema).json(jsonData.toDS)
+    dfFromJson.show()
+    val df = BaseSparkTest.createDF(collectionName, data, schema, contentType)
+    assertThat(df.collect()).isEqualTo(dfFromJson.collect())
+  }
+}

--- a/integration-tests/src/test/scala/org/apache/spark/sql/arangodb/datasource/DeserializationCastTest.scala
+++ b/integration-tests/src/test/scala/org/apache/spark/sql/arangodb/datasource/DeserializationCastTest.scala
@@ -1,6 +1,7 @@
 package org.apache.spark.sql.arangodb.datasource
 
 import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.arangodb.commons.ArangoOptions
 import org.apache.spark.sql.types.{BooleanType, DoubleType, IntegerType, StringType, StructField, StructType}
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Disabled
@@ -16,7 +17,7 @@ class DeserializationCastTest extends BaseSparkTest {
 
   @ParameterizedTest
   @ValueSource(strings = Array("vpack", "json"))
-  def numberIntToStringCast(contentType: String): Unit = doTestBadRecordImplicitCast(
+  def numberIntToStringCast(contentType: String): Unit = doTestImplicitCast(
     StructType(Array(StructField("a", StringType))),
     Seq(Map("a" -> 1)),
     Seq("""{"a":1}"""),
@@ -25,7 +26,7 @@ class DeserializationCastTest extends BaseSparkTest {
 
   @ParameterizedTest
   @ValueSource(strings = Array("vpack", "json"))
-  def numberDecToStringCast(contentType: String): Unit = doTestBadRecordImplicitCast(
+  def numberDecToStringCast(contentType: String): Unit = doTestImplicitCast(
     StructType(Array(StructField("a", StringType))),
     Seq(Map("a" -> 1.1)),
     Seq("""{"a":1.1}"""),
@@ -34,7 +35,7 @@ class DeserializationCastTest extends BaseSparkTest {
 
   @ParameterizedTest
   @ValueSource(strings = Array("vpack", "json"))
-  def boolToStringCast(contentType: String): Unit = doTestBadRecordImplicitCast(
+  def boolToStringCast(contentType: String): Unit = doTestImplicitCast(
     StructType(Array(StructField("a", StringType))),
     Seq(Map("a" -> true)),
     Seq("""{"a":true}"""),
@@ -43,7 +44,7 @@ class DeserializationCastTest extends BaseSparkTest {
 
   @ParameterizedTest
   @ValueSource(strings = Array("vpack", "json"))
-  def objectToStringCast(contentType: String): Unit = doTestBadRecordImplicitCast(
+  def objectToStringCast(contentType: String): Unit = doTestImplicitCast(
     StructType(Array(StructField("a", StringType))),
     Seq(Map("a" -> Map("b" -> "c"))),
     Seq("""{"a":{"b":"c"}}"""),
@@ -52,7 +53,7 @@ class DeserializationCastTest extends BaseSparkTest {
 
   @ParameterizedTest
   @ValueSource(strings = Array("vpack", "json"))
-  def arrayToStringCast(contentType: String): Unit = doTestBadRecordImplicitCast(
+  def arrayToStringCast(contentType: String): Unit = doTestImplicitCast(
     StructType(Array(StructField("a", StringType))),
     Seq(Map("a" -> Array(1, 2))),
     Seq("""{"a":[1,2]}"""),
@@ -61,7 +62,7 @@ class DeserializationCastTest extends BaseSparkTest {
 
   @ParameterizedTest
   @ValueSource(strings = Array("vpack", "json"))
-  def nullToIntegerCast(contentType: String): Unit = doTestBadRecordImplicitCast(
+  def nullToIntegerCast(contentType: String): Unit = doTestImplicitCast(
     StructType(Array(StructField("a", IntegerType, nullable = false))),
     Seq(Map("a" -> null)),
     Seq("""{"a":null}"""),
@@ -70,7 +71,7 @@ class DeserializationCastTest extends BaseSparkTest {
 
   @ParameterizedTest
   @ValueSource(strings = Array("vpack", "json"))
-  def nullToDoubleCast(contentType: String): Unit = doTestBadRecordImplicitCast(
+  def nullToDoubleCast(contentType: String): Unit = doTestImplicitCast(
     StructType(Array(StructField("a", DoubleType, nullable = false))),
     Seq(Map("a" -> null)),
     Seq("""{"a":null}"""),
@@ -79,14 +80,14 @@ class DeserializationCastTest extends BaseSparkTest {
 
   @ParameterizedTest
   @ValueSource(strings = Array("vpack", "json"))
-  def nullAsBoolean(contentType: String): Unit = doTestBadRecordImplicitCast(
+  def nullAsBoolean(contentType: String): Unit = doTestImplicitCast(
     StructType(Array(StructField("a", BooleanType, nullable = false))),
     Seq(Map("a" -> null)),
     Seq("""{"a":null}"""),
     contentType
   )
 
-  private def doTestBadRecordImplicitCast(
+  private def doTestImplicitCast(
                                            schema: StructType,
                                            data: Iterable[Map[String, Any]],
                                            jsonData: Seq[String],
@@ -95,7 +96,7 @@ class DeserializationCastTest extends BaseSparkTest {
     import spark.implicits._
     val dfFromJson: DataFrame = spark.read.schema(schema).json(jsonData.toDS)
     dfFromJson.show()
-    val df = BaseSparkTest.createDF(collectionName, data, schema, contentType)
+    val df = BaseSparkTest.createDF(collectionName, data, schema, Map(ArangoOptions.CONTENT_TYPE -> contentType))
     assertThat(df.collect()).isEqualTo(dfFromJson.collect())
   }
 }

--- a/integration-tests/src/test/scala/org/apache/spark/sql/arangodb/datasource/ReadTest.scala
+++ b/integration-tests/src/test/scala/org/apache/spark/sql/arangodb/datasource/ReadTest.scala
@@ -1,12 +1,9 @@
 package org.apache.spark.sql.arangodb.datasource
 
-import org.apache.spark.SparkException
 import org.apache.spark.sql.arangodb.commons.ArangoOptions
-import org.apache.spark.sql.catalyst.util.BadRecordException
 import org.apache.spark.sql.functions.col
-import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
-import org.assertj.core.api.Assertions.{assertThat, catchThrowable}
-import org.assertj.core.api.ThrowableAssert.ThrowingCallable
+import org.apache.spark.sql.types.{StringType, StructField, StructType}
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
@@ -40,31 +37,6 @@ class ReadTest extends BaseSparkTest {
     assertThat(litalien.gender).isEqualTo("female")
     assertThat(litalien.likes).isEqualTo(Seq("swimming", "chess"))
     assertThat(litalien.birthday).isEqualTo("1944-06-19")
-  }
-
-  @ParameterizedTest
-  @MethodSource(Array("provideProtocolAndContentType"))
-  def readCollectionWithBadRecords(protocol: String, contentType: String): Unit = {
-    val thrown = catchThrowable(new ThrowingCallable() {
-      override def call(): Unit =
-        spark.read
-          .format(BaseSparkTest.arangoDatasource)
-          .options(options + (
-            ArangoOptions.COLLECTION -> "users",
-            ArangoOptions.PROTOCOL -> protocol,
-            ArangoOptions.CONTENT_TYPE -> contentType
-          ))
-          .schema(new StructType(
-            Array(
-              StructField("likes", IntegerType)
-            )
-          ))
-          .load()
-          .show()
-    })
-
-    assertThat(thrown).isInstanceOf(classOf[SparkException])
-    assertThat(thrown.getCause).isInstanceOf(classOf[BadRecordException])
   }
 
   @Test

--- a/integration-tests/src/test/scala/org/apache/spark/sql/arangodb/datasource/ReadTest.scala
+++ b/integration-tests/src/test/scala/org/apache/spark/sql/arangodb/datasource/ReadTest.scala
@@ -1,12 +1,14 @@
 package org.apache.spark.sql.arangodb.datasource
 
+import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.arangodb.commons.ArangoOptions
 import org.apache.spark.sql.functions.col
-import org.apache.spark.sql.types.{StringType, StructField, StructType}
+import org.apache.spark.sql.types.{NumericType, StringType, StructField, StructType}
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.params.provider.{MethodSource, ValueSource}
 
 class ReadTest extends BaseSparkTest {
 
@@ -82,6 +84,62 @@ class ReadTest extends BaseSparkTest {
     assertThat(lastNameSchema.dataType).isInstanceOf(classOf[StringType])
     assertThat(lastNameSchema.nullable).isTrue
   }
+
+  @ParameterizedTest
+  @ValueSource(strings = Array("vpack", "json"))
+  def inferCollectionSchemaWithCorruptRecordColumn(contentType: String): Unit = {
+    assumeTrue(isSingle)
+
+    val additionalOptions = Map(
+      ArangoOptions.CORRUPT_RECORDS_COLUMN -> "badRecord",
+      ArangoOptions.SAMPLE_SIZE -> "2",
+      ArangoOptions.CONTENT_TYPE -> contentType
+    )
+
+    doInferCollectionSchemaWithCorruptRecordColumn(
+      BaseSparkTest.createQueryDF(
+        """FOR d IN [{"v":1},{"v":2},{"v":"3"}] RETURN d""",
+        schema = null,
+        additionalOptions
+      )
+    )
+
+    doInferCollectionSchemaWithCorruptRecordColumn(
+      BaseSparkTest.createDF(
+        "badData",
+        Seq(
+          Map("v" -> 1),
+          Map("v" -> 2),
+          Map("v" -> "3")
+        ),
+        schema = null,
+        additionalOptions
+      )
+    )
+  }
+
+  def doInferCollectionSchemaWithCorruptRecordColumn(df: DataFrame): Unit = {
+    val vSchema = df.schema("v")
+    assertThat(vSchema).isInstanceOf(classOf[StructField])
+    assertThat(vSchema.name).isEqualTo("v")
+    assertThat(vSchema.dataType).isInstanceOf(classOf[NumericType])
+    assertThat(vSchema.nullable).isTrue
+
+    val badRecordSchema = df.schema("badRecord")
+    assertThat(badRecordSchema).isInstanceOf(classOf[StructField])
+    assertThat(badRecordSchema.name).isEqualTo("badRecord")
+    assertThat(badRecordSchema.dataType).isInstanceOf(classOf[StringType])
+    assertThat(badRecordSchema.nullable).isTrue
+
+    val badRecords = df.filter("badRecord IS NOT NULL").persist()
+      .select("badRecord")
+      .collect()
+      .map(_ (0).asInstanceOf[String])
+
+    assertThat(badRecords).hasSize(1)
+    assertThat(badRecords.head).contains(""""v":"3""")
+  }
+
 
   @ParameterizedTest
   @MethodSource(Array("provideProtocolAndContentType"))


### PR DESCRIPTION
Allow setting bad record handling policy via config parameter, i.e.:

```
spark.read
    .option("mode", "PERMISSIVE|DROPMALFORMED|FAILFAST")
```

Review JacksonParser behavior and the cases in which it throws BadRecordException.Review official documentation of DataFrameReader#json (https://spark.apache.org/docs/3.1.2/api/java/org/apache/spark/sql/DataFrameReader.html#json-java.lang.String...-), in particular: 

```
mode (default PERMISSIVE): allows a mode for dealing with corrupt records during parsing.

    PERMISSIVE : when it meets a corrupted record, puts the malformed string into a field 
      configured by columnNameOfCorruptRecord, and sets malformed fields to null. To keep corrupt 
      records, an user can set a string type field named columnNameOfCorruptRecord in an 
      user-defined schema. If a schema does not have the field, it drops corrupt records during 
      parsing. When inferring a schema, it implicitly adds a columnNameOfCorruptRecord field in 
      an output schema.
    DROPMALFORMED : ignores the whole corrupted records.
    FAILFAST : throws an exception when it meets corrupted records.

columnNameOfCorruptRecord (default is the value specified in spark.sql.columnNameOfCorruptRecord): 
  allows renaming the new field having malformed string created by PERMISSIVE mode. This overrides 
  spark.sql.columnNameOfCorruptRecord.
```
