### PR TITLE
[DE-181] Retry only if schema has not nullable field _key

### DIFF
--- a/arangodb-spark-datasource-2.4/src/main/scala/org/apache/spark/sql/arangodb/datasource/writer/ArangoDataWriter.scala
+++ b/arangodb-spark-datasource-2.4/src/main/scala/org/apache/spark/sql/arangodb/datasource/writer/ArangoDataWriter.scala
@@ -57,12 +57,12 @@ class ArangoDataWriter(schema: StructType, options: ArangoDBConf, partitionId: I
   private def createClient() = ArangoClient(options.updated(ArangoDBConf.ENDPOINTS, endpoints(endpointIdx)))
 
   private def canRetry: Boolean =
-    options.writeOptions.overwriteMode match {
+    schema.exists(p => p.name == "_key" && !p.nullable) && (options.writeOptions.overwriteMode match {
       case OverwriteMode.ignore => true
       case OverwriteMode.replace => true
       case OverwriteMode.update => options.writeOptions.keepNull
       case OverwriteMode.conflict => false
-    }
+    })
 
   private def initBatch(): Unit = {
     batchCount = 0

--- a/arangodb-spark-datasource-2.4/src/main/scala/org/apache/spark/sql/arangodb/datasource/writer/ArangoDataWriter.scala
+++ b/arangodb-spark-datasource-2.4/src/main/scala/org/apache/spark/sql/arangodb/datasource/writer/ArangoDataWriter.scala
@@ -1,5 +1,6 @@
 package org.apache.spark.sql.arangodb.datasource.writer
 
+import com.arangodb.ArangoDBMultipleException
 import com.arangodb.model.OverwriteMode
 import com.arangodb.velocypack.{VPackParser, VPackSlice}
 import org.apache.spark.internal.Logging
@@ -11,7 +12,9 @@ import org.apache.spark.sql.sources.v2.writer.{DataWriter, WriterCommitMessage}
 import org.apache.spark.sql.types.StructType
 
 import java.io.ByteArrayOutputStream
+import java.net.{ConnectException, UnknownHostException}
 import scala.annotation.tailrec
+import scala.jdk.CollectionConverters.iterableAsScalaIterableConverter
 
 class ArangoDataWriter(schema: StructType, options: ArangoDBConf, partitionId: Int)
   extends DataWriter[InternalRow] with Logging {
@@ -94,7 +97,7 @@ class ArangoDataWriter(schema: StructType, options: ArangoDBConf, partitionId: I
         client.shutdown()
         failures += 1
         endpointIdx += 1
-        if (canRetry && failures < options.writeOptions.maxAttempts) {
+        if ((canRetry || isConnectionException(e)) && failures < options.writeOptions.maxAttempts) {
           logWarning("Got exception while saving documents: ", e)
           client = createClient()
           saveDocuments(payload)
@@ -102,6 +105,16 @@ class ArangoDataWriter(schema: StructType, options: ArangoDBConf, partitionId: I
           throw new ArangoDBDataWriterException(e, failures)
         }
     }
+  }
+
+  private def isConnectionException(e: Exception): Boolean = e.getCause match {
+    case mEx: ArangoDBMultipleException =>
+      mEx.getExceptions.asScala.forall {
+        case _: ConnectException => true
+        case _: UnknownHostException => true
+        case _ => false
+      }
+    case _ => false
   }
 
 }

--- a/arangodb-spark-datasource-3.1/src/main/scala/org/apache/spark/sql/arangodb/datasource/writer/ArangoDataWriter.scala
+++ b/arangodb-spark-datasource-3.1/src/main/scala/org/apache/spark/sql/arangodb/datasource/writer/ArangoDataWriter.scala
@@ -58,12 +58,12 @@ class ArangoDataWriter(schema: StructType, options: ArangoDBConf, partitionId: I
   private def createClient() = ArangoClient(options.updated(ArangoDBConf.ENDPOINTS, endpoints(endpointIdx)))
 
   private def canRetry: Boolean =
-    options.writeOptions.overwriteMode match {
+    schema.exists(p => p.name == "_key" && !p.nullable) && (options.writeOptions.overwriteMode match {
       case OverwriteMode.ignore => true
       case OverwriteMode.replace => true
       case OverwriteMode.update => options.writeOptions.keepNull
       case OverwriteMode.conflict => false
-    }
+    })
 
   private def initBatch(): Unit = {
     batchCount = 0

--- a/arangodb-spark-datasource-3.1/src/main/scala/org/apache/spark/sql/arangodb/datasource/writer/ArangoDataWriter.scala
+++ b/arangodb-spark-datasource-3.1/src/main/scala/org/apache/spark/sql/arangodb/datasource/writer/ArangoDataWriter.scala
@@ -1,5 +1,6 @@
 package org.apache.spark.sql.arangodb.datasource.writer
 
+import com.arangodb.ArangoDBMultipleException
 import com.arangodb.model.OverwriteMode
 import com.arangodb.velocypack.{VPackParser, VPackSlice}
 import org.apache.spark.internal.Logging
@@ -11,7 +12,9 @@ import org.apache.spark.sql.connector.write.{DataWriter, WriterCommitMessage}
 import org.apache.spark.sql.types.StructType
 
 import java.io.ByteArrayOutputStream
+import java.net.{ConnectException, UnknownHostException}
 import scala.annotation.tailrec
+import scala.jdk.CollectionConverters.iterableAsScalaIterableConverter
 
 class ArangoDataWriter(schema: StructType, options: ArangoDBConf, partitionId: Int)
   extends DataWriter[InternalRow] with Logging {
@@ -95,7 +98,7 @@ class ArangoDataWriter(schema: StructType, options: ArangoDBConf, partitionId: I
         client.shutdown()
         failures += 1
         endpointIdx += 1
-        if (canRetry && failures < options.writeOptions.maxAttempts) {
+        if ((canRetry || isConnectionException(e)) && failures < options.writeOptions.maxAttempts) {
           logWarning("Got exception while saving documents: ", e)
           client = createClient()
           saveDocuments(payload)
@@ -103,6 +106,16 @@ class ArangoDataWriter(schema: StructType, options: ArangoDBConf, partitionId: I
           throw new ArangoDBDataWriterException(e, failures)
         }
     }
+  }
+
+  private def isConnectionException(e: Exception): Boolean = e.getCause match {
+    case mEx: ArangoDBMultipleException =>
+      mEx.getExceptions.asScala.forall {
+        case _: ConnectException => true
+        case _: UnknownHostException => true
+        case _ => false
+      }
+    case _ => false
   }
 
 }

--- a/integration-tests/src/test/scala/org/apache/spark/sql/arangodb/datasource/write/AbortTest.scala
+++ b/integration-tests/src/test/scala/org/apache/spark/sql/arangodb/datasource/write/AbortTest.scala
@@ -58,6 +58,9 @@ class AbortTest extends BaseSparkTest {
   @ParameterizedTest
   @MethodSource(Array("provideProtocolAndContentType"))
   def dfWithNullableKeyFieldShouldNotRetry(protocol: String, contentType: String): Unit = {
+    // FIXME: https://arangodb.atlassian.net/browse/BTS-615
+    assumeTrue(isSingle)
+
     val nullableKeySchema = StructType(df.schema.map(p =>
       if (p.name == "_key") StructField(p.name, p.dataType)
       else p

--- a/integration-tests/src/test/scala/org/apache/spark/sql/arangodb/datasource/write/AbortTest.scala
+++ b/integration-tests/src/test/scala/org/apache/spark/sql/arangodb/datasource/write/AbortTest.scala
@@ -68,7 +68,7 @@ class AbortTest extends BaseSparkTest {
 
   private def shouldNotRetry(notRetryableDF: DataFrame, protocol: String, contentType: String): Unit = {
     val thrown = catchThrowable(new ThrowingCallable() {
-      override def call(): Unit = notRetryableDF.write
+      override def call(): Unit = notRetryableDF.repartition(1).write
         .format(BaseSparkTest.arangoDatasource)
         .mode(SaveMode.Append)
         .options(options + (

--- a/integration-tests/src/test/scala/org/apache/spark/sql/arangodb/datasource/write/WriteResiliencyTest.scala
+++ b/integration-tests/src/test/scala/org/apache/spark/sql/arangodb/datasource/write/WriteResiliencyTest.scala
@@ -65,11 +65,21 @@ class WriteResiliencyTest extends BaseSparkTest {
   @ParameterizedTest
   @MethodSource(Array("provideProtocolAndContentType"))
   def retryOnWrongHost(protocol: String, contentType: String): Unit = {
+    retryOnBadHost(BaseSparkTest.endpoints + ",172.17.0.1:8519", protocol, contentType)
+  }
+
+  @ParameterizedTest
+  @MethodSource(Array("provideProtocolAndContentType"))
+  def retryOnUnknownHost(protocol: String, contentType: String): Unit = {
+    retryOnBadHost(BaseSparkTest.endpoints + ",wrongHost:8529", protocol, contentType)
+  }
+
+  private def retryOnBadHost(endpoints: String, protocol: String, contentType: String): Unit = {
     df.write
       .format(BaseSparkTest.arangoDatasource)
       .mode(SaveMode.Append)
       .options(options + (
-        ArangoDBConf.ENDPOINTS -> (BaseSparkTest.endpoints + ",wrongHost:8529"),
+        ArangoDBConf.ENDPOINTS -> endpoints,
         ArangoDBConf.COLLECTION -> collectionName,
         ArangoDBConf.PROTOCOL -> protocol,
         ArangoDBConf.CONTENT_TYPE -> contentType,


### PR DESCRIPTION
- save requests are only retried if the dataframe schema has a not nullable field `_key`.
- connection exceptions are always retried
