### PR TITLE
[DE-190] validate schema before writing to edge collection

### DIFF
--- a/arangodb-spark-datasource-3.1/src/main/scala/org/apache/spark/sql/arangodb/datasource/writer/ArangoWriterBuilder.scala
+++ b/arangodb-spark-datasource-3.1/src/main/scala/org/apache/spark/sql/arangodb/datasource/writer/ArangoWriterBuilder.scala
@@ -1,16 +1,15 @@
 package org.apache.spark.sql.arangodb.datasource.writer
 
+import com.arangodb.entity.CollectionType
 import org.apache.spark.sql.arangodb.commons.{ArangoClient, ArangoDBConf, ContentType}
 import org.apache.spark.sql.connector.write.{BatchWrite, SupportsTruncate, WriteBuilder}
-import org.apache.spark.sql.types.{DecimalType, StructType}
+import org.apache.spark.sql.types.{DecimalType, StringType, StructType}
 import org.apache.spark.sql.{AnalysisException, SaveMode}
 
 class ArangoWriterBuilder(schema: StructType, options: ArangoDBConf) extends WriteBuilder with SupportsTruncate {
 
   private var mode: SaveMode = SaveMode.Append
-
-  if (options.driverOptions.contentType == ContentType.JSON && hasDecimalTypeFields)
-    throw new UnsupportedOperationException("Cannot write DecimalType when using contentType=json")
+  validateConfig()
 
   override def buildForBatch(): BatchWrite = {
     val client = ArangoClient(options)
@@ -37,6 +36,24 @@ class ArangoWriterBuilder(schema: StructType, options: ArangoDBConf) extends Wri
         "You are attempting to use overwrite mode which will truncate this collection prior to inserting data. If " +
           "you just want to change data already in the collection set save mode 'append' and " +
           s"'overwrite.mode=(replace|update)'. To actually truncate set '${ArangoDBConf.CONFIRM_TRUNCATE}=true'.")
+    }
+  }
+
+  private def validateConfig(): Unit = {
+    if (options.driverOptions.contentType == ContentType.JSON && hasDecimalTypeFields) {
+      throw new UnsupportedOperationException("Cannot write DecimalType when using contentType=json")
+    }
+
+    if (options.writeOptions.collectionType == CollectionType.EDGES &&
+      !schema.exists(p => p.name == "_from" && p.dataType == StringType && !p.nullable)
+    ) {
+      throw new IllegalArgumentException("Writing edge collection requires non nullable string field named _from.")
+    }
+
+    if (options.writeOptions.collectionType == CollectionType.EDGES &&
+      !schema.exists(p => p.name == "_to" && p.dataType == StringType && !p.nullable)
+    ) {
+      throw new IllegalArgumentException("Writing edge collection requires non nullable string field named _to.")
     }
   }
 

--- a/demo/src/main/scala/WriteDemo.scala
+++ b/demo/src/main/scala/WriteDemo.scala
@@ -1,3 +1,4 @@
+import org.apache.spark.sql.catalyst.expressions.objects.AssertNotNull
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{Column, DataFrame}
@@ -22,8 +23,8 @@ object WriteDemo {
       .withColumn("lastModified", unixTsToSparkTs(col("lastModified")))
       .persist()
     val edgesDF = Demo.spark.read.json(Demo.importPath + "/edges.jsonl")
-      .withColumn("_from", concat(lit("persons/"), col("_from")))
-      .withColumn("_to", concat(lit("movies/"), col("_to")))
+      .withColumn("_from", new Column(AssertNotNull(concat(lit("persons/"), col("_from")).expr)))
+      .withColumn("_to", new Column(AssertNotNull(concat(lit("movies/"), col("_to")).expr)))
       .persist()
 
     val personsDF = nodesDF

--- a/integration-tests/src/test/scala/org/apache/spark/sql/arangodb/datasource/write/AbortTest.scala
+++ b/integration-tests/src/test/scala/org/apache/spark/sql/arangodb/datasource/write/AbortTest.scala
@@ -37,8 +37,8 @@ class AbortTest extends BaseSparkTest {
   private val df = spark.createDataFrame(rows.asJava, StructType(Array(
     StructField("_key", StringType, nullable = false),
     StructField("name", StringType),
-    StructField("_from", StringType),
-    StructField("_to", StringType)
+    StructField("_from", StringType, nullable = false),
+    StructField("_to", StringType, nullable = false)
   )))
 
   @BeforeEach

--- a/integration-tests/src/test/scala/org/apache/spark/sql/arangodb/datasource/write/CreateCollectionTest.scala
+++ b/integration-tests/src/test/scala/org/apache/spark/sql/arangodb/datasource/write/CreateCollectionTest.scala
@@ -1,13 +1,16 @@
 package org.apache.spark.sql.arangodb.datasource.write
 
 import com.arangodb.ArangoCollection
-import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.{Row, SaveMode}
 import org.apache.spark.sql.arangodb.commons.{ArangoDBConf, CollectionType}
 import org.apache.spark.sql.arangodb.datasource.BaseSparkTest
+import org.apache.spark.sql.types.{StringType, StructField, StructType}
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
+
+import scala.jdk.CollectionConverters.seqAsJavaListConverter
 
 
 class CreateCollectionTest extends BaseSparkTest {
@@ -15,17 +18,19 @@ class CreateCollectionTest extends BaseSparkTest {
   private val collectionName = "chessPlayersCreateCollection"
   private val collection: ArangoCollection = db.collection(collectionName)
 
-  import spark.implicits._
+  private val rows = Seq(
+    Row("a/1", "b/1"),
+    Row("a/2", "b/2"),
+    Row("a/3", "b/3"),
+    Row("a/4", "b/4"),
+    Row("a/5", "b/5"),
+    Row("a/6", "b/6")
+  )
 
-  private val df = Seq(
-    ("a/1", "b/1"),
-    ("a/2", "b/2"),
-    ("a/3", "b/3"),
-    ("a/4", "b/4"),
-    ("a/5", "b/5"),
-    ("a/6", "b/6")
-  ).toDF("_from", "_to")
-    .repartition(3)
+  private val df = spark.createDataFrame(rows.asJava, StructType(Array(
+    StructField("_from", StringType, nullable = false),
+    StructField("_to", StringType, nullable = false)
+  ))).repartition(3)
 
   @BeforeEach
   def beforeEach(): Unit = {

--- a/integration-tests/src/test/scala/org/apache/spark/sql/arangodb/datasource/write/EdgeSchemaValidationTest.scala
+++ b/integration-tests/src/test/scala/org/apache/spark/sql/arangodb/datasource/write/EdgeSchemaValidationTest.scala
@@ -1,0 +1,92 @@
+package org.apache.spark.sql.arangodb.datasource.write
+
+import com.arangodb.ArangoCollection
+import org.apache.spark.sql.arangodb.commons.{ArangoDBConf, CollectionType}
+import org.apache.spark.sql.arangodb.datasource.BaseSparkTest
+import org.apache.spark.sql.types.{StringType, StructField, StructType}
+import org.apache.spark.sql.{DataFrame, Row, SaveMode}
+import org.assertj.core.api.Assertions.{assertThat, catchThrowable}
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
+import scala.jdk.CollectionConverters.seqAsJavaListConverter
+
+class EdgeSchemaValidationTest extends BaseSparkTest {
+
+  private val collectionName = "edgeSchemaValidationTest"
+  private val collection: ArangoCollection = db.collection(collectionName)
+
+  private val rows = Seq(
+    Row("k1", "from/from", "to/to"),
+    Row("k2", "from/from", "to/to"),
+    Row("k3", "from/from", "to/to")
+  )
+
+  private val df = spark.createDataFrame(rows.asJava, StructType(Array(
+    StructField("_key", StringType, nullable = false),
+    StructField("_from", StringType, nullable = false),
+    StructField("_to", StringType, nullable = false)
+  )))
+
+  @BeforeEach
+  def beforeEach(): Unit = {
+    if (collection.exists()) {
+      collection.drop()
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource(Array("provideProtocolAndContentType"))
+  def write(protocol: String, contentType: String): Unit = {
+    doWrite(df, protocol, contentType)
+    assertThat(collection.count().getCount).isEqualTo(3L)
+  }
+
+  @ParameterizedTest
+  @MethodSource(Array("provideProtocolAndContentType"))
+  def dfWithNullableFromFieldShouldFail(protocol: String, contentType: String): Unit = {
+    val nullableFromSchema = StructType(df.schema.map(p =>
+      if (p.name == "_from") StructField(p.name, p.dataType)
+      else p
+    ))
+    val dfWithNullableFrom = spark.createDataFrame(df.rdd, nullableFromSchema)
+    val thrown = catchThrowable(new ThrowingCallable() {
+      override def call(): Unit = doWrite(dfWithNullableFrom, protocol, contentType)
+    })
+
+    assertThat(thrown).isInstanceOf(classOf[IllegalArgumentException])
+    assertThat(thrown).hasMessageContaining("_from")
+  }
+
+  @ParameterizedTest
+  @MethodSource(Array("provideProtocolAndContentType"))
+  def dfWithNullableToFieldShouldFail(protocol: String, contentType: String): Unit = {
+    val nullableFromSchema = StructType(df.schema.map(p =>
+      if (p.name == "_to") StructField(p.name, p.dataType)
+      else p
+    ))
+    val dfWithNullableFrom = spark.createDataFrame(df.rdd, nullableFromSchema)
+    val thrown = catchThrowable(new ThrowingCallable() {
+      override def call(): Unit = doWrite(dfWithNullableFrom, protocol, contentType)
+    })
+
+    assertThat(thrown).isInstanceOf(classOf[IllegalArgumentException])
+    assertThat(thrown).hasMessageContaining("_to")
+  }
+
+  private def doWrite(testDF: DataFrame, protocol: String, contentType: String): Unit = {
+    testDF.write
+      .format(BaseSparkTest.arangoDatasource)
+      .mode(SaveMode.Append)
+      .options(options + (
+        ArangoDBConf.COLLECTION -> collectionName,
+        ArangoDBConf.PROTOCOL -> protocol,
+        ArangoDBConf.CONTENT_TYPE -> contentType,
+        ArangoDBConf.COLLECTION_TYPE -> CollectionType.EDGE.name
+      ))
+      .save()
+  }
+
+}


### PR DESCRIPTION
The schema of a Dataframe being written to an an edge collection must have:
- a non nullable string field named `_from`
- a non nullable string field named `_to`  