### PR TITLE
CI: test with Spark 4.1.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -499,6 +499,7 @@ workflows:
                 - '2.13.18'
               spark-full-version:
                 - '4.1.0'
+                - '4.1.1'
   test-python:
     when:
       not: <<pipeline.parameters.docker-img>>
@@ -541,7 +542,7 @@ workflows:
               scala-version:
                 - '2.13.18'
               pyspark-version:
-                - '4.1.0'
+                - '4.1.1'
   demo:
     when:
       not: <<pipeline.parameters.docker-img>>

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -63,7 +63,7 @@
         <profile>
             <id>spark-4.1</id>
             <properties>
-                <spark.version>4.1.0</spark.version>
+                <spark.version>4.1.1</spark.version>
                 <spark.compat.version>4.1</spark.compat.version>
                 <jackson.version>2.20.0</jackson.version>
             </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <profile>
             <id>spark-4.1</id>
             <properties>
-                <spark.version>4.1.0</spark.version>
+                <spark.version>4.1.1</spark.version>
                 <spark.compat.version>4.1</spark.compat.version>
                 <jackson.version>2.20.0</jackson.version>
             </properties>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates project to target Spark 4.1.1 and ensures CI coverage for it.
> 
> - Bumps `spark.version` for the `spark-4.1` profile from `4.1.0` to `4.1.1` in `pom.xml` and `demo/pom.xml`
> - Extends CircleCI matrices to include `spark-full-version` `4.1.1` and PySpark `4.1.1`; adjusts `test-python` to use `pyspark==4.1.1`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5a1a8586d8610d1442f8e6cc3e6f796750f7fba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->