### PR TITLE
Delegate SSL configuration to the driver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
         <dependency>
             <groupId>com.arangodb</groupId>
             <artifactId>arangodb-java-driver-shaded</artifactId>
-            <version>7.24.2</version>
+            <version>7.25.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Simplifies SSL/TLS handling by relying on the Java driver instead of custom SSL context code.
> 
> - In `ArangoDBConf.scala`, remove custom SSLContext creation and certificate/keystore parsing; set driver fields (`sslCertValue`, `sslProtocol`, `sslAlgorithm`, `sslTrustStorePath`, `sslTrustStorePassword`, `sslTrustStoreType`, `verifyHost`) directly in `builder()`
> - Update `pom.xml` to `arangodb-java-driver-shaded` version `7.25.0`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 590e87d5c0c8c993ee768b279f84ddfc8e8edc63. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->